### PR TITLE
UUID package moved

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid
 	"fmt"
 	"github.com/ninjasphere/app-scheduler/controller"
 	"github.com/ninjasphere/app-scheduler/model"


### PR DESCRIPTION
Project hosting on code.google.com shutdown on January 25, 2016. This package was migrated to github.com
